### PR TITLE
Add stubs to list of target branches

### DIFF
--- a/index_builder/packages.py
+++ b/index_builder/packages.py
@@ -32,7 +32,7 @@ def load_repository_packages(
     url = pathlib.Path(remote.url)
     raw_url = pathlib.Path(host) / url.parent.name / url.stem / "raw"
 
-    branches: List[str] = ["any"]
+    branches: List[str] = ["any", "stubs"]
     for platform in ("Linux", "Darwin", "Windows"):
         for version in ("3.6", "3.7", "3.8"):
             branches.append(platform + "_" + version)


### PR DESCRIPTION
I have created `stubs` and `stubs_pre` in rospypi/simple to place artifacts of rospypi/ros_stubs.
https://github.com/rospypi/simple/tree/stubs_pre
https://github.com/rospypi/simple/tree/stubs